### PR TITLE
Support quoted variable in pull()

### DIFF
--- a/R/pull.R
+++ b/R/pull.R
@@ -17,11 +17,13 @@
 #'
 #' @export
 pull <- function(.data, var = -1) {
-  var <- deparse(substitute(var))
+  var_deparse <- deparse(substitute(var))
   col_names <- colnames(.data)
-  if (!(var %in% col_names) & grepl("^[[:digit:]]+L|[[:digit:]]", var)) {
-    var <- as.integer(gsub("L", "", var))
+  if (!(var_deparse %in% col_names) & grepl("^[[:digit:]]+L|[[:digit:]]", var_deparse)) {
+    var <- as.integer(gsub("L", "", var_deparse))
     var <- ifelse(var < 1L, rev(col_names)[abs(var)], col_names[var])
+  } else if (var_deparse %in% col_names) {
+    var <- var_deparse
   }
   .data[, var]
 }


### PR DESCRIPTION
In `dplyr`, quoted variables also work in `pull()`, which makes it easy to combine with earlier set variables in code.

```r
mtcars %>% dplyr::pull("mpg")
#>  [1] 21.0 21.0 22.8 21.4 18.7 18.1 14.3 24.4 22.8 19.2 17.8 16.4 17.3 15.2 10.4 10.4 14.7 32.4 30.4 33.9 21.5 15.5 15.2 13.3 19.2 27.3 26.0 30.4
#> [29] 15.8 19.7 15.0 21.4
```

Suggested change supports this.