### PR TITLE
Fix arrange() for using in other functions

### DIFF
--- a/R/arrange.R
+++ b/R/arrange.R
@@ -21,7 +21,7 @@ arrange <- function(.data, ...) {
 
 #' @export
 arrange.default <- function(.data, ...) {
-  rows <- eval.parent(substitute(with(.data, order(...))))
+  rows <- eval(substitute(with(.data, order(...))), envir = .data)
   .data[rows, , drop = FALSE]
 }
 


### PR DESCRIPTION
If using `arrange()` inside nested functions or rmarkdown, it looked for the wrong environment. This is to fix that.