### PR TITLE
refactor: Clean pull implementation

### DIFF
--- a/R/pull.R
+++ b/R/pull.R
@@ -18,13 +18,14 @@
 #'
 #' @export
 pull <- function(.data, var = -1) {
-  var_deparse <- deparse_var(var)
-  col_names <- colnames(.data)
-  if (!(var_deparse %in% col_names) & grepl("^[[:digit:]]+L|[[:digit:]]", var_deparse)) {
-    var <- as.integer(gsub("L", "", var_deparse))
-    var <- if_else(var < 1L, rev(col_names)[abs(var)], col_names[var])
-  } else if (var_deparse %in% col_names) {
-    var <- var_deparse
-  }
-  .data[, var]
+
+  var_list <- as.list(seq_along(.data))
+
+  names(var_list) <- names(.data)
+
+  .var <- eval(substitute(var), var_list)
+
+  if (.var < 0) .var <- length(var_list) + .var + 1
+
+  .data[[.var]]
 }


### PR DESCRIPTION
Slightly cleaner `pull()` implementation. It's a bit faster too (not that this matters much, it's a pretty light function either way).

``` r
data_size <- 100000
test_df <- data.frame(a = rep(1, data_size), b = rep(2, data_size), c = rep(3, data_size))

bench::mark(current = poorman::pull(test_df, -1),
            new = new_pull(test_df, -1),
            check = TRUE, iterations = 50)
#> # A tibble: 2 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 current      65.5µs   66.7µs    14578.     166KB       0 
#> 2 new          16.7µs   17.6µs    52253.        0B    1066.
```