### PR TITLE
Fix arrange() with character vectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# poorman 0.2.6 (devel)
+
+* `arrange()` now works for descending character vectors (@etiennebacher).
+
 # poorman 0.2.5
 
 Ninth CRAN release.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # poorman 0.2.6 (devel)
 
-* `arrange()` now works for descending character vectors (@etiennebacher).
+* `arrange()` now works for descending character vectors (#99, @etiennebacher).
 
 # poorman 0.2.5
 

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -44,7 +44,7 @@ arrange_rows <- function(.data, dots) {
       tmp <- gsub("^desc\\(", "-", tmp)
       tmp <- gsub("\\)$", "", tmp)
     }
-    dots[[i]] <- str2lang(tmp)
+    dots[[i]] <- parse(text = tmp, keep.source = FALSE)[[1]]
   }
 
   # convert character colums used to arrange to factor columns, so that we can

--- a/inst/tinytest/test_arrange.R
+++ b/inst/tinytest/test_arrange.R
@@ -148,3 +148,45 @@ expect_equal(
   ),
   info = "grouped arrange() ignores group, unless requested with .by_group"
 )
+
+# with character columns
+df <- data.frame(x = c("a", "b", "a", "b"),
+                 y = c("c", "c", "c", "d"),
+                 z = c(4, 2, 1, 3))
+expect_equal(
+  df %>% arrange(-x),
+  df[order(df$x, decreasing = TRUE), ]
+)
+expect_equal(
+  df %>% arrange(-x, y),
+  data.frame(x = c("b", "b", "a", "a"),
+             y = c("c", "d", "c", "c"),
+             z = c(2, 3, 4, 1)) %>%
+    structure(row.names = c(2L, 4L, 1L, 3L))
+)
+expect_equal(
+  df %>% arrange(-x, y, z),
+  data.frame(x = c("b", "b", "a", "a"),
+             y = c("c", "d", "c", "c"),
+             z = c(2, 3, 1, 4)) %>%
+    structure(row.names = c(2L, 4L, 3L, 1L))
+)
+
+expect_equal(
+  df %>% arrange(desc(x)),
+  df[order(df$x, decreasing = TRUE), ]
+)
+expect_equal(
+  df %>% arrange(desc(x), y),
+  data.frame(x = c("b", "b", "a", "a"),
+             y = c("c", "d", "c", "c"),
+             z = c(2, 3, 4, 1)) %>%
+    structure(row.names = c(2L, 4L, 1L, 3L))
+)
+expect_equal(
+  df %>% arrange(desc(x), y, z),
+  data.frame(x = c("b", "b", "a", "a"),
+             y = c("c", "d", "c", "c"),
+             z = c(2, 3, 1, 4)) %>%
+    structure(row.names = c(2L, 4L, 3L, 1L))
+)


### PR DESCRIPTION
Close #85
``` r
df <- data.frame(x = head(letters), stringsAsFactors = FALSE)
poorman::arrange(df, -x)
#>   x
#> 6 f
#> 5 e
#> 4 d
#> 3 c
#> 2 b
#> 1 a

set.seed(2022)
df <- data.frame(
  x = sample(c("A", "B"), 6, replace = TRUE),
  y = 1:6
)
df
#>   x y
#> 1 B 1
#> 2 A 2
#> 3 B 3
#> 4 A 4
#> 5 A 5
#> 6 B 6
poorman::arrange(df, -x, y)
#>   x y
#> 1 B 1
#> 3 B 3
#> 6 B 6
#> 2 A 2
#> 4 A 4
#> 5 A 5
```

<sup>Created on 2022-07-28 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
