### PR TITLE
Fix: arrange() should reset rownames when they are numeric

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Initial versions of `pivot_longer()` and `pivot_wider()` have been added (#101, @etiennebacher).
 * The `.names` argument in `across()` now accepts `{.col}` and `{.fn}` to automatically name new columns (#100, @etiennebacher).
 * `arrange()` now works for descending character vectors (#99, @etiennebacher).
+* `arrange()` now resets row names when they are numeric (#102, @etiennebacher).
 
 # poorman 0.2.5
 

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -24,7 +24,11 @@ arrange.data.frame <- function(.data, ..., .by_group = FALSE) {
   is_grouped <- has_groups(.data)
   if (isTRUE(.by_group)) dots <- c(groups(.data), dots)
   rows <- arrange_rows(.data = .data, dots)
+  row_number <- attr(.data, "row.names") # row.names returns a character vector
   out <- .data[rows, , drop = FALSE]
+  if (is.numeric(row_number)) {
+    row.names(out) <- row_number
+  }
   if (is_grouped) {
     attr(out, "groups") <- calculate_groups(out, group_vars(out))
   }

--- a/inst/tinytest/test_arrange.R
+++ b/inst/tinytest/test_arrange.R
@@ -35,7 +35,7 @@ expect_equal(
 df <- data.frame(x = 1:3, y = 3:1 + 2i)
 expect_equal(
   arrange(df, y),
-  df[3:1, ],
+  data.frame(x = 3:1, y = 1:3 + 2i),
   info = "arrange() handles complex columns"
 )
 
@@ -48,7 +48,7 @@ setMethod(
 df <- data.frame(x = 1:3, y = TestS4(3:1))
 expect_equal(
   arrange(df, y),
-  df[3:1, ],
+  data.frame(x = 3:1, y = TestS4(1:3)),
   info = "arrange handles S4 classes"
 )
 removeClass("TestS4")
@@ -106,7 +106,7 @@ expect_equal(
 df <- data.frame(x = 1:4, y = 5:8)
 expect_equal(
   arrange(df, -x * y),
-  structure(list(x = 4:1, y = 8:5), row.names = 4:1, class = "data.frame"),
+  structure(list(x = 4:1, y = 8:5), row.names = 1:4, class = "data.frame"),
   info = "arrange() can add and arrange by new columns (#89)"
 )
 
@@ -134,7 +134,7 @@ expect_equal(
     groups = structure(
       list(g = c(1, 2), .rows = list(c(1L, 3L), c(2L, 4L))), row.names = 1:2, class = "data.frame", .drop = TRUE
     ),
-    row.names = 4:1,
+    row.names = 1:4,
     class = c("grouped_df", "data.frame")
   ),
   info = "grouped arrange() ignores group_by groups"
@@ -144,7 +144,7 @@ expect_equal(
   structure(
     list(g = c(1, 1, 2, 2), x = c(1L, 3L, 2L, 4L)),
     groups = structure(list(g = c(1, 2), .rows = list(1:2, 3:4)), row.names = 1:2, class = "data.frame", .drop = TRUE),
-    row.names = c(4L, 2L, 3L, 1L), class = c("grouped_df", "data.frame")
+    row.names = 1:4, class = c("grouped_df", "data.frame")
   ),
   info = "grouped arrange() ignores group, unless requested with .by_group"
 )
@@ -155,38 +155,42 @@ df <- data.frame(x = c("a", "b", "a", "b"),
                  z = c(4, 2, 1, 3))
 expect_equal(
   df %>% arrange(-x),
-  df[order(df$x, decreasing = TRUE), ]
+  data.frame(x = c("b", "b", "a", "a"),
+             y = c("c", "d", "c", "c"),
+             z = c(2, 3, 4, 1))
 )
 expect_equal(
   df %>% arrange(-x, y),
   data.frame(x = c("b", "b", "a", "a"),
              y = c("c", "d", "c", "c"),
              z = c(2, 3, 4, 1)) %>%
-    structure(row.names = c(2L, 4L, 1L, 3L))
+    structure(row.names = 1:4)
 )
 expect_equal(
   df %>% arrange(-x, y, z),
   data.frame(x = c("b", "b", "a", "a"),
              y = c("c", "d", "c", "c"),
              z = c(2, 3, 1, 4)) %>%
-    structure(row.names = c(2L, 4L, 3L, 1L))
+    structure(row.names = 1:4)
 )
 
 expect_equal(
   df %>% arrange(desc(x)),
-  df[order(df$x, decreasing = TRUE), ]
+  data.frame(x = c("b", "b", "a", "a"),
+             y = c("c", "d", "c", "c"),
+             z = c(2, 3, 4, 1))
 )
 expect_equal(
   df %>% arrange(desc(x), y),
   data.frame(x = c("b", "b", "a", "a"),
              y = c("c", "d", "c", "c"),
              z = c(2, 3, 4, 1)) %>%
-    structure(row.names = c(2L, 4L, 1L, 3L))
+    structure(row.names = 1:4)
 )
 expect_equal(
   df %>% arrange(desc(x), y, z),
   data.frame(x = c("b", "b", "a", "a"),
              y = c("c", "d", "c", "c"),
              z = c(2, 3, 1, 4)) %>%
-    structure(row.names = c(2L, 4L, 3L, 1L))
+    structure(row.names = 1:4)
 )


### PR DESCRIPTION
Closes #86. 

Before:
``` r
suppressPackageStartupMessages({
  library(poorman)
})

# Should reset row names
df <- data.frame(x = head(letters))
arrange(df, -x)
#>   x
#> 6 f
#> 5 e
#> 4 d
#> 3 c
#> 2 b
#> 1 a

# Shouldn't reset row names
head(mtcars) %>% 
  arrange(mpg)
#>                    mpg cyl disp  hp drat    wt  qsec vs am gear carb
#> Valiant           18.1   6  225 105 2.76 3.460 20.22  1  0    3    1
#> Hornet Sportabout 18.7   8  360 175 3.15 3.440 17.02  0  0    3    2
#> Mazda RX4         21.0   6  160 110 3.90 2.620 16.46  0  1    4    4
#> Mazda RX4 Wag     21.0   6  160 110 3.90 2.875 17.02  0  1    4    4
#> Hornet 4 Drive    21.4   6  258 110 3.08 3.215 19.44  1  0    3    1
#> Datsun 710        22.8   4  108  93 3.85 2.320 18.61  1  1    4    1
```

<sup>Created on 2022-08-02 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

After:
``` r
suppressPackageStartupMessages({
  library(poorman)
})

# Should reset row names
df <- data.frame(x = head(letters))
arrange(df, -x)
#>   x
#> 1 f
#> 2 e
#> 3 d
#> 4 c
#> 5 b
#> 6 a

# Shouldn't reset row names
head(mtcars) %>% 
  arrange(mpg)
#>                    mpg cyl disp  hp drat    wt  qsec vs am gear carb
#> Valiant           18.1   6  225 105 2.76 3.460 20.22  1  0    3    1
#> Hornet Sportabout 18.7   8  360 175 3.15 3.440 17.02  0  0    3    2
#> Mazda RX4         21.0   6  160 110 3.90 2.620 16.46  0  1    4    4
#> Mazda RX4 Wag     21.0   6  160 110 3.90 2.875 17.02  0  1    4    4
#> Hornet 4 Drive    21.4   6  258 110 3.08 3.215 19.44  1  0    3    1
#> Datsun 710        22.8   4  108  93 3.85 2.320 18.61  1  1    4    1
```

<sup>Created on 2022-08-02 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
