### PR TITLE
Fix: distinct() resets row names if they are numeric

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * The `.names` argument in `across()` now accepts `{.col}` and `{.fn}` to automatically name new columns (#100, @etiennebacher).
 * `arrange()` now works for descending character vectors (#99, @etiennebacher).
 * `arrange()` now resets row names when they are numeric (#102, @etiennebacher).
+* `distinct()` now resets row names when they are numeric (#106, @etiennebacher).
 
 # poorman 0.2.5
 

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -78,6 +78,9 @@ distinct.data.frame <- function(.data, ..., .keep_all = FALSE) {
     res <- cbind(res, .data[rownames(res), setdiff(colnames(.data), colnames(res)), drop = FALSE])
   }
   common_cols <- c(intersect(colnames(.data), colnames(res)), setdiff(col_names, colnames(.data)))
+  if (is.numeric(attr(res, "row.names"))) {
+    row.names(res) <- 1:nrow(res)
+  }
   if (length(common_cols) > 0L) res[, common_cols, drop = FALSE] else res
 }
 

--- a/inst/tinytest/test_distinct.R
+++ b/inst/tinytest/test_distinct.R
@@ -13,7 +13,7 @@ expect_equal(
 )
 expect_equal(
   distinct(df, y, .keep_all = FALSE),
-  unique(df["y"]),
+  data.frame(y = 1:2),
   info = "distinct() for single column works as expected"
 )
 
@@ -46,6 +46,19 @@ expect_equal(
   "a",
   "distinct() doesn't duplicate columns"
 )
+
+expect_equal(
+  row.names(distinct(df, y)),
+  c("1", "2"),
+  info = "distinct() reset row names when they are numeric"
+)
+
+expect_equal(
+  row.names(distinct(head(mtcars, 3), mpg)),
+  c("Mazda RX4", "Datsun 710"),
+  info = "distinct() keeps row names when they are character"
+)
+
 expect_equal(
   data.frame(a = 1:3, b = 4:6) %>% group_by(a) %>% distinct(a) %>% colnames(),
   "a",


### PR DESCRIPTION
Close #104. New behavior:
``` r
suppressPackageStartupMessages(library(poorman))

df <- data.frame(
  a = c(1, 1, 2, 2),
  b = c(3, 4, 5, 6)
)

df %>% 
  dplyr::distinct(a, .keep_all = TRUE)
#>   a b
#> 1 1 3
#> 2 2 5

df %>% 
  poorman::distinct(a, .keep_all = TRUE)
#>   a b
#> 1 1 3
#> 2 2 5
```

<sup>Created on 2022-08-02 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
