### PR TITLE
Leave out unnecessary packages from `Suggests`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,8 +14,6 @@ BugReports: https://github.com/nathaneastwood/poorman/issues
 Depends: R (>= 3.3)
 Suggests:
     knitr,
-    pkgdown,
-    markdown,
     rmarkdown,
     roxygen2,
     tinytest


### PR DESCRIPTION
IINM, there is no source or test code that uses any of the functions from these packages, so including them here should be unnecessary.