### PR TITLE
fix: relocate() works when .before and .after called in a function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# poorman 0.2.7.9000 (devel)
+
+The following fixes were also implemented:
+
+* `relocate()` now works correctly when its arguments `.before` and `.after`
+  are passed through a function (#114, @etiennebacher).
+
 # poorman 0.2.6
 
 This update adds the following features:

--- a/R/relocate.R
+++ b/R/relocate.R
@@ -51,8 +51,22 @@ relocate.data.frame <- function(.data, ..., .before = NULL, .after = NULL) {
   data_names <- colnames(.data)
   col_pos <- select_positions(.data, ...)
 
-  if (!missing(.before)) .before <- colnames(.data)[eval_select_pos(.data, substitute(.before))]
-  if (!missing(.after)) .after <- colnames(.data)[eval_select_pos(.data, substitute(.after))]
+  if (!missing(.before)) {
+    x <- try(eval_expr(.before), silent = TRUE)
+    if (inherits(x, "try-error")) {
+      .before <- colnames(.data)[eval_select_pos(.data, substitute(.before))]
+    } else {
+      .before <- colnames(.data)[eval_select_pos(.data, .before)]
+    }
+  }
+  if (!missing(.after)) {
+    x <- try(eval_expr(.after), silent = TRUE)
+    if (inherits(x, "try-error")) {
+      .after <- colnames(.data)[eval_select_pos(.data, substitute(.after))]
+    } else {
+      .after <- colnames(.data)[eval_select_pos(.data, .after)]
+    }
+  }
 
   has_before <- !is.null(.before)
   has_after <- !is.null(.after)

--- a/R/relocate.R
+++ b/R/relocate.R
@@ -52,17 +52,21 @@ relocate.data.frame <- function(.data, ..., .before = NULL, .after = NULL) {
   col_pos <- select_positions(.data, ...)
 
   if (!missing(.before)) {
-    x <- try(eval_expr(.before), silent = TRUE)
+    x <- try(eval(.before), silent = TRUE)
     if (inherits(x, "try-error")) {
       .before <- colnames(.data)[eval_select_pos(.data, substitute(.before))]
+    } else if (is.null(x)) {
+      .after <- NULL
     } else {
       .before <- colnames(.data)[eval_select_pos(.data, .before)]
     }
   }
   if (!missing(.after)) {
-    x <- try(eval_expr(.after), silent = TRUE)
+    x <- try(eval(.after), silent = TRUE)
     if (inherits(x, "try-error")) {
       .after <- colnames(.data)[eval_select_pos(.data, substitute(.after))]
+    } else if (is.null(x)) {
+      .after <- NULL
     } else {
       .after <- colnames(.data)[eval_select_pos(.data, .after)]
     }

--- a/inst/tinytest/test_relocate.R
+++ b/inst/tinytest/test_relocate.R
@@ -44,3 +44,23 @@ expect_error(
   mtcars %>% relocate(gear, .after = mpg, .before = cyl),
   info = "relocate() fails when .after and .before are both given"
 )
+
+myFun <- function(location) {
+  relocate(mtcars, gear, .after = location)
+}
+
+expect_equal(
+  myFun(1),
+  mtcars[, c("mpg", "gear", "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am", "carb")],
+  info = "relocate() works when .after is passed through a function"
+)
+
+myFun <- function(location) {
+  relocate(mtcars, gear, .before = location)
+}
+
+expect_equal(
+  myFun(1),
+  mtcars[, c("gear", "mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am", "carb")],
+  info = "relocate() works when .before is passed through a function"
+)


### PR DESCRIPTION
Close #110. I didn't use the code you put in #110 because it didn't seem to work. Maybe my solution can be simplified. 

``` r
myFun <- function(location_before = NULL, location_after = NULL) {
  poorman::relocate(head(mtcars), gear, .before = location_before, .after = location_after)
}
myFun()
#>                   gear  mpg cyl disp  hp drat    wt  qsec vs am carb
#> Mazda RX4            4 21.0   6  160 110 3.90 2.620 16.46  0  1    4
#> Mazda RX4 Wag        4 21.0   6  160 110 3.90 2.875 17.02  0  1    4
#> Datsun 710           4 22.8   4  108  93 3.85 2.320 18.61  1  1    1
#> Hornet 4 Drive       3 21.4   6  258 110 3.08 3.215 19.44  1  0    1
#> Hornet Sportabout    3 18.7   8  360 175 3.15 3.440 17.02  0  0    2
#> Valiant              3 18.1   6  225 105 2.76 3.460 20.22  1  0    1
myFun(location_before = 2)
#>                    mpg gear cyl disp  hp drat    wt  qsec vs am carb
#> Mazda RX4         21.0    4   6  160 110 3.90 2.620 16.46  0  1    4
#> Mazda RX4 Wag     21.0    4   6  160 110 3.90 2.875 17.02  0  1    4
#> Datsun 710        22.8    4   4  108  93 3.85 2.320 18.61  1  1    1
#> Hornet 4 Drive    21.4    3   6  258 110 3.08 3.215 19.44  1  0    1
#> Hornet Sportabout 18.7    3   8  360 175 3.15 3.440 17.02  0  0    2
#> Valiant           18.1    3   6  225 105 2.76 3.460 20.22  1  0    1
myFun(location_after = 2)
#>                   gear  mpg cyl disp  hp drat    wt  qsec vs am carb
#> Mazda RX4            4 21.0   6  160 110 3.90 2.620 16.46  0  1    4
#> Mazda RX4 Wag        4 21.0   6  160 110 3.90 2.875 17.02  0  1    4
#> Datsun 710           4 22.8   4  108  93 3.85 2.320 18.61  1  1    1
#> Hornet 4 Drive       3 21.4   6  258 110 3.08 3.215 19.44  1  0    1
#> Hornet Sportabout    3 18.7   8  360 175 3.15 3.440 17.02  0  0    2
#> Valiant              3 18.1   6  225 105 2.76 3.460 20.22  1  0    1
```

<sup>Created on 2022-08-27 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Only works if the argument passed are numeric.