### PR TITLE
Improve speed of `group_by()`

### DIFF
--- a/R/group_utils.R
+++ b/R/group_utils.R
@@ -63,16 +63,18 @@ calculate_groups <- function(data, groups, drop = group_by_drop_default(data)) {
   unique_groups <- unique(data[, groups, drop = FALSE])
   is_factor <- do.call(c, lapply(unique_groups, function(x) is.factor(x)))
   n_comb <- nrow(unique_groups)
-  rows <- rep(list(NA), n_comb)
-  data_groups <- interaction(data[, groups, drop = TRUE])
   
+  temp_id <- paste(sample(letters), collapse = "")
+
   # Concatenate group variables
-  pasted_groups <- do.call(paste, c(unique_groups[, groups, drop = FALSE], sep = "."))
-  pasted_groups[is.na(unique_groups)] <- NA
-  
+  pasted_groups <- do.call(paste, c(unique_groups, sep = "."))
+  data[[temp_id]] <- do.call(paste, c(data[, groups, drop = FALSE], sep = "."))
+
+  rows <- rep(list(NA), n_comb)
   for (i in seq_len(n_comb)) {
-    rows[[i]] <- which(data_groups %in% pasted_groups[i])
+    rows[[i]] <- which(data[[temp_id]] %in% pasted_groups[i])
   }
+  data[[temp_id]] <- NULL
 
   if (!isTRUE(drop) && any(is_factor)) {
     na_lvls <- do.call(

--- a/R/group_utils.R
+++ b/R/group_utils.R
@@ -65,8 +65,13 @@ calculate_groups <- function(data, groups, drop = group_by_drop_default(data)) {
   n_comb <- nrow(unique_groups)
   rows <- rep(list(NA), n_comb)
   data_groups <- interaction(data[, groups, drop = TRUE])
+  
+  # Concatenate group variables
+  pasted_groups <- do.call(paste, c(unique_groups[, groups, drop = FALSE], sep = "."))
+  pasted_groups[is.na(unique_groups)] <- NA
+  
   for (i in seq_len(n_comb)) {
-    rows[[i]] <- which(data_groups %in% interaction(unique_groups[i, groups]))
+    rows[[i]] <- which(data_groups %in% pasted_groups[i])
   }
 
   if (!isTRUE(drop) && any(is_factor)) {

--- a/inst/tinytest/test_group_by.R
+++ b/inst/tinytest/test_group_by.R
@@ -177,7 +177,7 @@ expect_identical(
 d <- data.frame(
   orig = rep(c("France", "UK"), each = 4),
   dest = rep(c("Spain", "Germany"), times = 4),
-  year = rep(c(2010, 2011), each = 4),
+  year = rep(rep(c(2010, 2011), each = 2), 2),
   value = 1:8
 )
 d[2, 1] <- NA

--- a/inst/tinytest/test_group_by.R
+++ b/inst/tinytest/test_group_by.R
@@ -189,13 +189,19 @@ res <- d %>%
 
 expect_identical(nrow(res), 6L)
 expect_identical(
-  res[5:6, 1:2],
+  res[5:6, 1:3],
   structure(
-    data.frame(orig = c("UK", NA), dest = c(NA, "Germany")),
+    list2DF(
+      list(
+        orig = c("UK", NA), 
+        dest = c(NA, "Germany"), 
+        .rows = list(7L, 2L)
+      )
+    ),
     row.names = 5:6
   )
 )
 expect_identical(
   vapply(res$.rows, length, FUN.VALUE = numeric(1L)),
-  c(1, 2, 2, 1, 0, 2)
+  c(1, 2, 2, 1, 1, 1)
 )


### PR DESCRIPTION
Related to #119.

Benchmark setup:
```r
d <- data.frame(
  g1 = sample(LETTERS, 8000, TRUE),
  g2 = sample(LETTERS, 8000, TRUE),
  g3 = sample(LETTERS, 8000, TRUE),
  x1 = runif(8000),
  x2 = runif(8000),
  x3 = runif(8000)
)

# return a list of results so that both functions return the same output (without
# all the class problem, tibble vs data.frame)
poor = function() {
  foo <- d %>% 
    group_by(g1, g2, g3) |> 
    summarise(x1 = mean(x1), x2 = max(x2), x3 = min(x3))

  list(foo$x1, foo$x2, foo$x3)
}

dpl = function() {
  foo <- d %>% 
    dplyr::group_by(g1, g2, g3) |> 
    dplyr::summarise(x1 = mean(x1), x2 = max(x2), x3 = min(x3))

  list(foo$x1, foo$x2, foo$x3)
}

bench::mark(
  poor(),
  dpl()
)
```

**Before:**
```r
#> # A tibble: 2 × 13
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result     memory     time           gc      
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>     <list>     <list>         <list>  
#> 1 poor()        11.6s    11.6s    0.0863    1.83GB    11.0      1   127      11.6s <list [3]> <Rprofmem> <bench_tm [1]> <tibble>
#> 2 dpl()       157.2ms  178.3ms    5.77      7.34MB     5.77     3     3    520.2ms <list [3]> <Rprofmem> <bench_tm [3]> <tibble>
```


**After:**
```r
#> # A tibble: 2 × 13
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result     memory     time           gc      
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>     <list>     <list>         <list>  
#> 1 poor()        7.77s    7.77s     0.129    1.83GB     9.78     1    76      7.77s <list [3]> <Rprofmem> <bench_tm [1]> <tibble>
#> 2 dpl()      112.42ms 152.17ms     6.66     3.39MB     3.33     4     2   601.02ms <list [3]> <Rprofmem> <bench_tm [4]> <tibble>
```